### PR TITLE
Add code sniffer and missing return types

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="CatfishPHP">
+    <description>
+        Catfish PHP style guide
+    </description>
+
+    <rule ref="PSR2"/>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "tightenco/collect": "^5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1"
+        "phpunit/phpunit": "^7.1",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "license": "MIT",
     "autoload": {
@@ -16,5 +17,8 @@
             "Catfish\\Container\\": "src/",
             "Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "sniff": "vendor/bin/phpcs --standard=.phpcs.xml -n --extensions=php src tests"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "daca4ffac7c7a98199a4923dfb830af5",
+    "content-hash": "ab5613c886a9dc3aa93c35b0e441e631",
     "packages": [
         {
             "name": "psr/container",
@@ -1653,6 +1653,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Container.php
+++ b/src/Container.php
@@ -60,7 +60,7 @@ class Container implements ContainerInterface, \ArrayAccess
      * @param string $id
      * @return bool
      */
-    public function has($id)
+    public function has($id): bool
     {
         $container = $this->getContainer();
 
@@ -69,7 +69,7 @@ class Container implements ContainerInterface, \ArrayAccess
 
     /**
      * @param string $key
-     * @param $concrete
+     * @param mixed  $concrete
      */
     public function add(string $key, $concrete)
     {
@@ -113,7 +113,7 @@ class Container implements ContainerInterface, \ArrayAccess
      * @param mixed $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->getContainer()->offsetExists($offset);
     }
@@ -131,7 +131,7 @@ class Container implements ContainerInterface, \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->getContainer()->offsetSet($offset, $value);
     }
@@ -139,7 +139,7 @@ class Container implements ContainerInterface, \ArrayAccess
     /**
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->getContainer()->offsetUnset($offset);
     }


### PR DESCRIPTION
## Feature
* Add a new `composer sniff` command to the project to check for PSR2 code standards.
* Add several missing return type declarations

## Impact
* No changes to testing or library